### PR TITLE
Fix android namespace issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,8 @@ kotlin {
     }
 
     linuxX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {
@@ -70,7 +72,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.configcat"
+    namespace = "com.configcat.openfeature"
     compileSdk = 36
 
     defaultConfig {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.configcat
-version=0.2.0
+version=0.3.0
 
 kotlin.code.style=official
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.2.10"
 android-gradle-plugin = "8.11.1"
 configcat = "5.1.0"
-openfeature = "0.6.2"
+openfeature = "0.8.0"
 ktor = "3.2.3"
 kotlinx-serialization = "1.9.0"
 kotlinx-coroutines= "1.10.2"

--- a/samples/android/app/build.gradle.kts
+++ b/samples/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
@@ -28,9 +27,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
     buildFeatures {
         compose = true
     }
@@ -46,7 +42,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("com.configcat:configcat-openfeature-provider:0.2.0")
+    implementation("com.configcat:configcat-openfeature-provider:0.3.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
+    id("com.android.application") version "9.0.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.0" apply false
 }

--- a/samples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,2 +1,2 @@
 #Sat Jun 14 12:42:36 CEST 2025
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip

--- a/src/commonMain/kotlin/com/configcat/ConfigCatProvider.kt
+++ b/src/commonMain/kotlin/com/configcat/ConfigCatProvider.kt
@@ -53,7 +53,7 @@ class ConfigCatProvider(
         options.hooks.addOnConfigChanged { _, sn ->
             snapshot.store(sn)
             if (sn.cacheState != ClientCacheState.NO_FLAG_DATA && initialized.compareAndSet(expectedValue = false, newValue = true)) {
-                if (!events.tryEmit(OpenFeatureProviderEvents.ProviderReady)) {
+                if (!events.tryEmit(OpenFeatureProviderEvents.ProviderReady())) {
                     initialized.store(false)
                 }
             }
@@ -66,7 +66,7 @@ class ConfigCatProvider(
         user.store(initialUser)
         val state = client.waitForReady()
         if (state != ClientCacheState.NO_FLAG_DATA && initialized.compareAndSet(expectedValue = false, newValue = true)) {
-            events.emit(OpenFeatureProviderEvents.ProviderReady)
+            events.emit(OpenFeatureProviderEvents.ProviderReady())
         }
     }
 

--- a/src/commonTest/kotlin/com/configcat/ProviderTests.kt
+++ b/src/commonTest/kotlin/com/configcat/ProviderTests.kt
@@ -209,7 +209,7 @@ class ProviderTests {
             val collectJob =
                 launch {
                     provider.observe().collect {
-                        if (it == OpenFeatureProviderEvents.ProviderReady) {
+                        if (it == OpenFeatureProviderEvents.ProviderReady()) {
                             ready = true
                         }
                     }
@@ -261,7 +261,7 @@ class ProviderTests {
             val collectJob =
                 launch {
                     provider.observe().collect {
-                        if (it == OpenFeatureProviderEvents.ProviderReady) {
+                        if (it == OpenFeatureProviderEvents.ProviderReady()) {
                             ready = true
                         }
                     }


### PR DESCRIPTION
### Describe the purpose of your pull request
- Fix android namespace collision between this package and the ConfigCat Kotlin SDK (`com.configcat` -> `com.configcat.openfeature`)
- Updated the OpenFeature SDK to the latest version.
- Added missing targets supported by the OpenFeature SDK (`iosArm64`, `iosArm64Simulator`)

### Related issues (only if applicable)
- #6 

### Security (only if applicable)
- n/a

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
